### PR TITLE
change timestamps and depositID and fundingID to uint64

### DIFF
--- a/contracts/DInterestWithDepositFee.sol
+++ b/contracts/DInterestWithDepositFee.sol
@@ -97,13 +97,13 @@ contract DInterestWithDepositFee is DInterest {
      */
     function _deposit(
         uint256 depositAmount,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool rollover
     )
         internal
         virtual
         override
-        returns (uint256 depositID, uint256 interestAmount)
+        returns (uint64 depositID, uint256 interestAmount)
     {
         (depositID, interestAmount) = _depositRecordData(
             _applyDepositFee(depositAmount),
@@ -115,7 +115,7 @@ contract DInterestWithDepositFee is DInterest {
     /**
         @dev See {topupDeposit}
      */
-    function _topupDeposit(uint256 depositID, uint256 depositAmount)
+    function _topupDeposit(uint64 depositID, uint256 depositAmount)
         internal
         virtual
         override
@@ -131,11 +131,11 @@ contract DInterestWithDepositFee is DInterest {
     /**
         @dev See {fund}
      */
-    function _fund(uint256 depositID, uint256 fundAmount)
+    function _fund(uint64 depositID, uint256 fundAmount)
         internal
         virtual
         override
-        returns (uint256 fundingID)
+        returns (uint64 fundingID)
     {
         uint256 actualFundAmount;
         (fundingID, actualFundAmount) = _fundRecordData(

--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -62,7 +62,7 @@ contract Factory {
         bytes32 salt,
         address _pool,
         address _vesting,
-        uint256 _maturationTimetstamp,
+        uint64 _maturationTimetstamp,
         uint256 _initialDepositAmount,
         string calldata _tokenName,
         string calldata _tokenSymbol

--- a/contracts/models/fee/IFeeModel.sol
+++ b/contracts/models/fee/IFeeModel.sol
@@ -6,13 +6,13 @@ interface IFeeModel {
 
     function getInterestFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 interestAmount
     ) external view returns (uint256 feeAmount);
 
     function getEarlyWithdrawFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 withdrawnDepositAmount
     ) external view returns (uint256 feeAmount);
 }

--- a/contracts/models/fee/PercentageFeeModel.sol
+++ b/contracts/models/fee/PercentageFeeModel.sol
@@ -59,7 +59,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function getInterestFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 interestAmount
     ) external view override returns (uint256 feeAmount) {
         uint256 feeRate;
@@ -84,7 +84,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function getEarlyWithdrawFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 withdrawnDepositAmount
     ) external view override returns (uint256 feeAmount) {
         uint256 feeRate;
@@ -154,7 +154,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function overrideInterestFeeForDeposit(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 newFee
     ) external onlyOwner {
         require(newFee <= interestFee, "PercentageFeeModel: too big");
@@ -167,7 +167,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function overrideEarlyWithdrawFeeForDeposit(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 newFee
     ) external onlyOwner {
         require(newFee <= earlyWithdrawFee, "PercentageFeeModel: too big");

--- a/contracts/models/issuance/IMPHIssuanceModel.sol
+++ b/contracts/models/issuance/IMPHIssuanceModel.sol
@@ -63,7 +63,7 @@ interface IMPHIssuanceModel {
         address pool,
         uint256 depositAmount,
         uint256 fundingCreationTimestamp,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool early
     )
         external
@@ -89,7 +89,7 @@ interface IMPHIssuanceModel {
         @notice The multiplier applied when minting MPH for a pool's depositor reward.
                 Unit is MPH-wei per depositToken-wei per second. (wei here is the smallest decimal place)
                 Scaled by 10^18.
-                NOTE: The depositToken's decimals matter! 
+                NOTE: The depositToken's decimals matter!
      */
     function poolDepositorRewardMintMultiplier(address pool)
         external

--- a/contracts/models/issuance/MPHIssuanceModel02.sol
+++ b/contracts/models/issuance/MPHIssuanceModel02.sol
@@ -16,7 +16,7 @@ contract MPHIssuanceModel02 is OwnableUpgradeable, IMPHIssuanceModel {
         @notice The multiplier applied when minting MPH for a pool's depositor reward.
                 Unit is MPH-wei per depositToken-wei per second. (wei here is the smallest decimal place)
                 Scaled by 10^18.
-                NOTE: The depositToken's decimals matter! 
+                NOTE: The depositToken's decimals matter!
      */
     mapping(address => uint256)
         public
@@ -163,7 +163,7 @@ contract MPHIssuanceModel02 is OwnableUpgradeable, IMPHIssuanceModel {
         address pool,
         uint256 depositAmount,
         uint256 fundingCreationTimestamp,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool early
     )
         external

--- a/contracts/rewards/MPHMinter.sol
+++ b/contracts/rewards/MPHMinter.sol
@@ -58,7 +58,7 @@ contract MPHMinter is MPHMinterLegacy {
     /**
         v3 functions
      */
-    function createVestForDeposit(address account, uint256 depositID)
+    function createVestForDeposit(address account, uint64 depositID)
         external
         onlyRole(WHITELISTED_POOL_ROLE)
     {
@@ -71,7 +71,7 @@ contract MPHMinter is MPHMinterLegacy {
     }
 
     function updateVestForDeposit(
-        uint256 depositID,
+        uint64 depositID,
         uint256 currentDepositAmount,
         uint256 depositAmount
     ) external onlyRole(WHITELISTED_POOL_ROLE) {
@@ -98,7 +98,7 @@ contract MPHMinter is MPHMinterLegacy {
         return amount;
     }
 
-    function distributeFundingRewards(uint256 fundingID, uint256 interestAmount)
+    function distributeFundingRewards(uint64 fundingID, uint256 interestAmount)
         external
         onlyRole(WHITELISTED_POOL_ROLE)
     {

--- a/contracts/rewards/MPHMinterLegacy.sol
+++ b/contracts/rewards/MPHMinterLegacy.sol
@@ -197,7 +197,7 @@ contract MPHMinterLegacy is AccessControlUpgradeable {
         address to,
         uint256 depositAmount,
         uint256 fundingCreationTimestamp,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         uint256 interestPayoutAmount,
         bool early
     ) external onlyRole(WHITELISTED_POOL_ROLE) returns (uint256) {

--- a/contracts/rewards/Vesting02.sol
+++ b/contracts/rewards/Vesting02.sol
@@ -18,7 +18,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
 
     struct Vest {
         address pool;
-        uint256 depositID;
+        uint64 depositID;
         uint256 lastUpdateTimestamp;
         uint256 accumulatedAmount;
         uint256 withdrawnAmount;
@@ -35,7 +35,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
     event ECreateVest(
         address indexed to,
         address indexed pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 vestAmountPerStablecoinPerSecond
     );
     event EUpdateVest(uint256 indexed vestID);
@@ -65,7 +65,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
     function createVestForDeposit(
         address to,
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 vestAmountPerStablecoinPerSecond
     ) external returns (uint256 vestID) {
         require(
@@ -94,7 +94,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
     }
 
     function updateVestForDeposit(
-        uint256 depositID,
+        uint64 depositID,
         uint256 currentDepositAmount,
         uint256 depositAmount,
         uint256 vestAmountPerStablecoinPerSecond

--- a/contracts/zaps/ZapCurve.sol
+++ b/contracts/zaps/ZapCurve.sol
@@ -30,7 +30,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
         address inputToken,
         uint256 inputTokenAmount,
         uint256 minOutputTokenAmount,
-        uint256 maturationTimestamp
+        uint64 maturationTimestamp
     ) external active {
         DInterest poolContract = DInterest(pool);
         ERC20Upgradeable stablecoin = poolContract.stablecoin();
@@ -47,7 +47,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
 
         // create deposit
         stablecoin.safeIncreaseAllowance(pool, outputTokenAmount);
-        (uint256 depositID, ) =
+        (uint64 depositID, ) =
             poolContract.deposit(outputTokenAmount, maturationTimestamp);
 
         // transfer deposit multitokens to msg.sender
@@ -60,7 +60,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
         address inputToken,
         uint256 inputTokenAmount,
         uint256 minOutputTokenAmount,
-        uint256 depositID
+        uint64 depositID
     ) external active {
         DInterest poolContract = DInterest(pool);
         ERC20Upgradeable stablecoin = poolContract.stablecoin();
@@ -77,7 +77,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
 
         // create funding
         stablecoin.safeIncreaseAllowance(pool, outputTokenAmount);
-        uint256 fundingID = poolContract.fund(depositID, outputTokenAmount);
+        uint64 fundingID = poolContract.fund(depositID, outputTokenAmount);
 
         // transfer funding multitoken to msg.sender
         fundingMultitoken.safeTransferFrom(

--- a/contracts/zero-coupon-bond/ZeroCouponBond.sol
+++ b/contracts/zero-coupon-bond/ZeroCouponBond.sol
@@ -20,8 +20,8 @@ contract ZeroCouponBond is
     ERC20Upgradeable public stablecoin;
     NFT public depositNFT;
     Vesting02 public vesting;
-    uint256 public maturationTimestamp;
-    uint256 public depositID;
+    uint64 public maturationTimestamp;
+    uint64 public depositID;
     uint8 public _decimals;
 
     event WithdrawDeposit();
@@ -31,7 +31,7 @@ contract ZeroCouponBond is
         address _creator,
         address _pool,
         address _vesting,
-        uint256 _maturationTimestamp,
+        uint64 _maturationTimestamp,
         uint256 _initialDepositAmount,
         string calldata _tokenName,
         string calldata _tokenSymbol


### PR DESCRIPTION
This changes both timestamps (`maturationTimestamp` and `depositTimestamp`) and `fundingID` and `depositID` from uint256 to uint64. It saves up to 7 % gas on the methods, but deployment gets up to 5 % more expensive.
In practise the gas savings should be even bigger, because the lists (`fundingList` and `deposits`) in production are even longer (than in the tests).

```
CERC20Mock.mint:
min:  330471 ->  326733 (-1.1%)
max:  472428 ->  468690 (-0.8%)
avg:  364902 ->  361164 (-1.0%)
DInterest.deposit:
min:  552499 ->  513125 (-7.1%)
max:  738399 ->  699025 (-5.3%)
avg:  668214 ->  628839 (-5.9%)
DInterest.fund:
min:  256452 ->  256961 (0.2%)
max:  523511 ->  510793 (-2.4%)
avg:  396291 ->  385463 (-2.7%)
DInterest.payInterestToFunders:
min:  201421 ->  201695 (0.1%)
max:  358448 ->  358722 (0.1%)
avg:  257921 ->  258195 (0.1%)
DInterest.rolloverDeposit:
min:  529215 ->  488803 (-7.6%)
max:  672300 ->  631888 (-6.0%)
avg:  566370 ->  525958 (-7.1%)
DInterest.topupDeposit:
min:  261787 ->  258034 (-1.4%)
max:  403744 ->  399991 (-0.9%)
avg:  296218 ->  292465 (-1.3%)
DInterest.withdraw:
min:   78906 ->   78276 (-0.8%)
max:  382749 ->  380370 (-0.6%)
avg:  188683 ->  187520 (-0.6%)

Factory.createZeroCouponBond:
min: 1060529 ->  983322 (-7.3%)
max: 1166574 -> 1089367 (-6.6%)
avg: 1100119 -> 1022912 (-7.0%)

MPHIssuanceModel02.setPoolFunderRewardVestPeriod:
min:   26688 ->   26754 (0.2%)
max:   26700 ->   26766 (0.2%)
avg:   26699 ->   26765 (0.2%)

DInterest.DEPLOY:
avg: 4904146 -> 5143821 (4.9%)
Factory.DEPLOY:
avg: 1282064 -> 1287243 (0.4%)
MPHIssuanceModel02.DEPLOY:
avg:  824335 ->  833197 (1.1%)
MPHMinter.DEPLOY:
avg: 2403768 -> 2430977 (1.1%)
PercentageFeeModel.DEPLOY:
avg:  846664 ->  862235 (1.8%)
Vesting02.DEPLOY:
avg: 2387390 -> 2415235 (1.2%)
ZeroCouponBond.DEPLOY:
avg: 2010356 -> 2070353 (3.0%)
```
