### PR TITLE
use uint64 for timestamps and fundingID and depositID

### DIFF
--- a/contracts/DInterest.sol
+++ b/contracts/DInterest.sol
@@ -61,17 +61,17 @@ contract DInterest is
         uint256 virtualTokenTotalSupply; // depositAmount + interestAmount, behaves like a zero coupon bond
         uint256 interestRate; // interestAmount = interestRate * depositAmount
         uint256 feeRate; // feeAmount = feeRate * interestAmount
-        uint256 maturationTimestamp; // Unix timestamp after which the deposit may be withdrawn, in seconds
-        uint256 depositTimestamp; // Unix timestamp at time of deposit, in seconds
         uint256 averageRecordedIncomeIndex; // Average income index at time of deposit, used for computing deposit surplus
-        uint256 fundingID; // The ID of the associated Funding struct. 0 if not funded.
+        uint64 maturationTimestamp; // Unix timestamp after which the deposit may be withdrawn, in seconds
+        uint64 depositTimestamp; // Unix timestamp at time of deposit, in seconds
+        uint64 fundingID; // The ID of the associated Funding struct. 0 if not funded.
     }
     Deposit[] internal deposits;
 
     // Funding data
     // Each funding has an ID used in the fundingMultitoken, which is equal to its index in `fundingList` plus 1
     struct Funding {
-        uint256 depositID; // The ID of the associated Deposit struct.
+        uint64 depositID; // The ID of the associated Deposit struct.
         uint256 recordedMoneyMarketIncomeIndex; // the income index at the last update (creation or withdrawal)
         uint256 principalPerToken; // The amount of stablecoins that's earning interest for you per funding token you own. Scaled to 18 decimals regardless of stablecoin decimals.
     }
@@ -112,29 +112,29 @@ contract DInterest is
         uint256 depositAmount,
         uint256 interestAmount,
         uint256 feeAmount,
-        uint256 maturationTimestamp
+        uint64 maturationTimestamp
     );
     event ETopupDeposit(
         address indexed sender,
-        uint256 indexed depositID,
+        uint64 indexed depositID,
         uint256 depositAmount,
         uint256 interestAmount,
         uint256 feeAmount
     );
     event ERolloverDeposit(
         address indexed sender,
-        uint256 indexed depositID,
-        uint256 indexed newDepositID
+        uint64 indexed depositID,
+        uint64 indexed newDepositID
     );
     event EWithdraw(
         address indexed sender,
-        uint256 indexed depositID,
+        uint64 indexed depositID,
         uint256 tokenAmount,
         uint256 feeAmount
     );
     event EFund(
         address indexed sender,
-        uint256 indexed fundingID,
+        uint64 indexed fundingID,
         uint256 fundAmount,
         uint256 tokenAmount
     );
@@ -277,10 +277,10 @@ contract DInterest is
         @return depositID The ID of the created deposit
         @return interestAmount The amount of fixed-rate interest
      */
-    function deposit(uint256 depositAmount, uint256 maturationTimestamp)
+    function deposit(uint256 depositAmount, uint64 maturationTimestamp)
         external
         nonReentrant
-        returns (uint256 depositID, uint256 interestAmount)
+        returns (uint64 depositID, uint256 interestAmount)
     {
         return _deposit(msg.sender, depositAmount, maturationTimestamp, false);
     }
@@ -292,7 +292,7 @@ contract DInterest is
         @param depositAmount The amount to top up, in stablecoin
         @return interestAmount The amount of interest that will be earned by the topped up funds at maturation
      */
-    function topupDeposit(uint256 depositID, uint256 depositAmount)
+    function topupDeposit(uint64 depositID, uint256 depositAmount)
         external
         nonReentrant
         returns (uint256 interestAmount)
@@ -307,7 +307,7 @@ contract DInterest is
         @param maturationTimestamp The Unix timestamp of the new deposit, in seconds
         @return newDepositID The ID of the new deposit
      */
-    function rolloverDeposit(uint256 depositID, uint256 maturationTimestamp)
+    function rolloverDeposit(uint64 depositID, uint64 maturationTimestamp)
         external
         nonReentrant
         returns (uint256 newDepositID, uint256 interestAmount)
@@ -325,7 +325,7 @@ contract DInterest is
         @return withdrawnStablecoinAmount the amount of stablecoins withdrawn
      */
     function withdraw(
-        uint256 depositID,
+        uint64 depositID,
         uint256 virtualTokenAmount,
         bool early
     ) external nonReentrant returns (uint256 withdrawnStablecoinAmount) {
@@ -345,10 +345,10 @@ contract DInterest is
                           the surplus value instead.
         @param fundingID The ID of the fundingMultitoken the sender received
      */
-    function fund(uint256 depositID, uint256 fundAmount)
+    function fund(uint64 depositID, uint256 fundAmount)
         external
         nonReentrant
-        returns (uint256 fundingID)
+        returns (uint64 fundingID)
     {
         return _fund(msg.sender, depositID, fundAmount);
     }
@@ -359,7 +359,7 @@ contract DInterest is
         @param fundingID The ID of the floating-rate bond
         @return interestAmount The amount of interest distributed, in stablecoins
      */
-    function payInterestToFunders(uint256 fundingID)
+    function payInterestToFunders(uint64 fundingID)
         external
         returns (uint256 interestAmount)
     {
@@ -372,7 +372,7 @@ contract DInterest is
 
     function sponsoredDeposit(
         uint256 depositAmount,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         Sponsorship calldata sponsorship
     )
         external
@@ -382,7 +382,7 @@ contract DInterest is
             this.sponsoredDeposit.selector,
             abi.encode(depositAmount, maturationTimestamp)
         )
-        returns (uint256 depositID, uint256 interestAmount)
+        returns (uint64 depositID, uint256 interestAmount)
     {
         return
             _deposit(
@@ -394,7 +394,7 @@ contract DInterest is
     }
 
     function sponsoredTopupDeposit(
-        uint256 depositID,
+        uint64 depositID,
         uint256 depositAmount,
         Sponsorship calldata sponsorship
     )
@@ -411,8 +411,8 @@ contract DInterest is
     }
 
     function sponsoredRolloverDeposit(
-        uint256 depositID,
-        uint256 maturationTimestamp,
+        uint64 depositID,
+        uint64 maturationTimestamp,
         Sponsorship calldata sponsorship
     )
         external
@@ -433,7 +433,7 @@ contract DInterest is
     }
 
     function sponsoredWithdraw(
-        uint256 depositID,
+        uint64 depositID,
         uint256 virtualTokenAmount,
         bool early,
         Sponsorship calldata sponsorship
@@ -458,7 +458,7 @@ contract DInterest is
     }
 
     function sponsoredFund(
-        uint256 depositID,
+        uint64 depositID,
         uint256 fundAmount,
         Sponsorship calldata sponsorship
     )
@@ -469,13 +469,13 @@ contract DInterest is
             this.sponsoredFund.selector,
             abi.encode(depositID, fundAmount)
         )
-        returns (uint256 fundingID)
+        returns (uint64 fundingID)
     {
         return _fund(sponsorship.sender, depositID, fundAmount);
     }
 
     function sponsoredPayInterestToFunders(
-        uint256 fundingID,
+        uint64 fundingID,
         Sponsorship calldata sponsorship
     )
         external
@@ -583,7 +583,7 @@ contract DInterest is
         @return isNegative True if the surplus is negative, false otherwise
         @return surplusAmount The absolute value of the surplus, in stablecoins
      */
-    function rawSurplusOfDeposit(uint256 depositID)
+    function rawSurplusOfDeposit(uint64 depositID)
         public
         virtual
         returns (bool isNegative, uint256 surplusAmount)
@@ -620,14 +620,14 @@ contract DInterest is
         @return isNegative True if the surplus is negative, false otherwise
         @return surplusAmount The absolute value of the surplus, in stablecoins
      */
-    function surplusOfDeposit(uint256 depositID)
+    function surplusOfDeposit(uint64 depositID)
         public
         virtual
         returns (bool isNegative, uint256 surplusAmount)
     {
         (isNegative, surplusAmount) = rawSurplusOfDeposit(depositID);
 
-        uint256 fundingID = _getDeposit(depositID).fundingID;
+        uint64 fundingID = _getDeposit(depositID).fundingID;
         if (fundingID != 0) {
             uint256 totalPrincipal =
                 _depositVirtualTokenToPrincipal(
@@ -659,7 +659,7 @@ contract DInterest is
         @return feeAmount The amount of fees that will be given to the beneficiary
      */
     function withdrawableAmountOfDeposit(
-        uint256 depositID,
+        uint64 depositID,
         uint256 virtualTokenAmount
     ) external view returns (uint256 withdrawableAmount, uint256 feeAmount) {
         // Verify input
@@ -699,7 +699,7 @@ contract DInterest is
         @param fundingID The ID of the floating-rate bond
         @return The interest accrued, in stablecoins
      */
-    function accruedInterestOfFunding(uint256 fundingID)
+    function accruedInterestOfFunding(uint64 fundingID)
         external
         returns (uint256)
     {
@@ -728,7 +728,7 @@ contract DInterest is
         @param depositID The ID of the deposit
         @return The deposit struct
      */
-    function getDeposit(uint256 depositID)
+    function getDeposit(uint64 depositID)
         external
         view
         returns (Deposit memory)
@@ -742,7 +742,7 @@ contract DInterest is
         @param fundingID The ID of the floating-rate bond
         @return The Funding struct
      */
-    function getFunding(uint256 fundingID)
+    function getFunding(uint64 fundingID)
         external
         view
         returns (Funding memory)
@@ -758,7 +758,7 @@ contract DInterest is
         @param fundingID The ID of the floating-rate bond
         @return True if the funding is active, false otherwise
      */
-    function fundingIsActive(uint256 fundingID) external view returns (bool) {
+    function fundingIsActive(uint64 fundingID) external view returns (bool) {
         return _fundingIsActive(fundingID);
     }
 
@@ -782,9 +782,9 @@ contract DInterest is
     function _deposit(
         address sender,
         uint256 depositAmount,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool rollover
-    ) internal virtual returns (uint256 depositID, uint256 interestAmount) {
+    ) internal virtual returns (uint64 depositID, uint256 interestAmount) {
         (depositID, interestAmount) = _depositRecordData(
             sender,
             depositAmount,
@@ -796,8 +796,8 @@ contract DInterest is
     function _depositRecordData(
         address sender,
         uint256 depositAmount,
-        uint256 maturationTimestamp
-    ) internal virtual returns (uint256 depositID, uint256 interestAmount) {
+        uint64 maturationTimestamp
+    ) internal virtual returns (uint64 depositID, uint256 interestAmount) {
         // Ensure input is valid
         require(
             depositAmount >= MinDepositAmount,
@@ -814,7 +814,7 @@ contract DInterest is
         require(interestAmount > 0, "DInterest: interestAmount == 0");
 
         // Calculate fee
-        depositID = deposits.length + 1;
+        depositID = uint64(deposits.length) + 1;
         uint256 feeAmount =
             feeModel.getInterestFeeAmount(
                 address(this),
@@ -830,7 +830,7 @@ contract DInterest is
                 interestRate: interestAmount.decdiv(depositAmount),
                 feeRate: feeAmount.decdiv(interestAmount),
                 maturationTimestamp: maturationTimestamp,
-                depositTimestamp: block.timestamp,
+                depositTimestamp: uint64(block.timestamp),
                 fundingID: 0,
                 averageRecordedIncomeIndex: moneyMarket.incomeIndex()
             })
@@ -880,7 +880,7 @@ contract DInterest is
      */
     function _topupDeposit(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 depositAmount
     ) internal virtual returns (uint256 interestAmount) {
         interestAmount = _topupDepositRecordData(
@@ -893,7 +893,7 @@ contract DInterest is
 
     function _topupDepositRecordData(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 depositAmount
     ) internal virtual returns (uint256 interestAmount) {
         Deposit memory depositEntry = _getDeposit(depositID);
@@ -989,9 +989,9 @@ contract DInterest is
      */
     function _rolloverDeposit(
         address sender,
-        uint256 depositID,
-        uint256 maturationTimestamp
-    ) internal virtual returns (uint256 newDepositID, uint256 interestAmount) {
+        uint64 depositID,
+        uint64 maturationTimestamp
+    ) internal virtual returns (uint64 newDepositID, uint256 interestAmount) {
         // withdraw from existing deposit
         uint256 withdrawnStablecoinAmount =
             _withdraw(sender, depositID, type(uint256).max, false, true);
@@ -1013,7 +1013,7 @@ contract DInterest is
      */
     function _withdraw(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 virtualTokenAmount,
         bool early,
         bool rollover
@@ -1038,7 +1038,7 @@ contract DInterest is
 
     function _withdrawRecordData(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 virtualTokenAmount,
         bool early
     )
@@ -1162,7 +1162,7 @@ contract DInterest is
 
     function _withdrawTransferFunds(
         address sender,
-        uint256 fundingID,
+        uint64 fundingID,
         uint256 withdrawAmount,
         uint256 feeAmount,
         uint256 fundingInterestAmount,
@@ -1263,9 +1263,9 @@ contract DInterest is
      */
     function _fund(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 fundAmount
-    ) internal virtual returns (uint256 fundingID) {
+    ) internal virtual returns (uint64 fundingID) {
         uint256 actualFundAmount;
         (fundingID, actualFundAmount) = _fundRecordData(
             sender,
@@ -1277,9 +1277,9 @@ contract DInterest is
 
     function _fundRecordData(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 fundAmount
-    ) internal virtual returns (uint256 fundingID, uint256 actualFundAmount) {
+    ) internal virtual returns (uint64 fundingID, uint256 actualFundAmount) {
         Deposit storage depositEntry = _getDeposit(depositID);
 
         (bool isNegative, uint256 surplusMagnitude) = surplus();
@@ -1311,7 +1311,7 @@ contract DInterest is
                     principalPerToken: ULTRA_PRECISION
                 })
             );
-            fundingID = fundingList.length;
+            fundingID = uint64(fundingList.length);
             depositEntry.fundingID = fundingID;
             totalPrincipalToFund =
                 (totalPrincipal * fundAmount) /
@@ -1373,7 +1373,7 @@ contract DInterest is
     /**
         @dev See {payInterestToFunders}
      */
-    function _payInterestToFunders(uint256 fundingID)
+    function _payInterestToFunders(uint64 fundingID)
         internal
         virtual
         returns (uint256 interestAmount)
@@ -1433,7 +1433,7 @@ contract DInterest is
         @return refundAmount The amount of refund caused by an early withdraw
      */
     function _computeAndUpdateFundingInterestAfterWithdraw(
-        uint256 fundingID,
+        uint64 fundingID,
         uint256 recordedFundedPrincipalAmount,
         bool early
     )
@@ -1522,7 +1522,7 @@ contract DInterest is
     /**
         @dev See {getDeposit}
      */
-    function _getDeposit(uint256 depositID)
+    function _getDeposit(uint64 depositID)
         internal
         view
         returns (Deposit storage)
@@ -1533,7 +1533,7 @@ contract DInterest is
     /**
         @dev See {getFunding}
      */
-    function _getFunding(uint256 fundingID)
+    function _getFunding(uint64 fundingID)
         internal
         view
         returns (Funding storage)
@@ -1544,7 +1544,7 @@ contract DInterest is
     /**
         @dev See {fundingIsActive}
      */
-    function _fundingIsActive(uint256 fundingID) internal view returns (bool) {
+    function _fundingIsActive(uint64 fundingID) internal view returns (bool) {
         return _getFunding(fundingID).principalPerToken > 0;
     }
 
@@ -1556,7 +1556,7 @@ contract DInterest is
         @return The corresponding principal value
      */
     function _depositVirtualTokenToPrincipal(
-        uint256 depositID,
+        uint64 depositID,
         uint256 virtualTokenAmount
     ) internal view virtual returns (uint256) {
         Deposit storage depositEntry = _getDeposit(depositID);
@@ -1572,7 +1572,7 @@ contract DInterest is
     /**
         @dev See {accruedInterestOfFunding}
      */
-    function _accruedInterestOfFunding(uint256 fundingID)
+    function _accruedInterestOfFunding(uint64 fundingID)
         internal
         virtual
         returns (uint256 fundingInterestAmount)

--- a/contracts/DInterestWithDepositFee.sol
+++ b/contracts/DInterestWithDepositFee.sol
@@ -63,13 +63,13 @@ contract DInterestWithDepositFee is DInterest {
     function _deposit(
         address sender,
         uint256 depositAmount,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool rollover
     )
         internal
         virtual
         override
-        returns (uint256 depositID, uint256 interestAmount)
+        returns (uint64 depositID, uint256 interestAmount)
     {
         (depositID, interestAmount) = _depositRecordData(
             sender,
@@ -84,7 +84,7 @@ contract DInterestWithDepositFee is DInterest {
      */
     function _topupDeposit(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 depositAmount
     ) internal virtual override returns (uint256 interestAmount) {
         interestAmount = _topupDepositRecordData(
@@ -100,9 +100,9 @@ contract DInterestWithDepositFee is DInterest {
      */
     function _fund(
         address sender,
-        uint256 depositID,
+        uint64 depositID,
         uint256 fundAmount
-    ) internal virtual override returns (uint256 fundingID) {
+    ) internal virtual override returns (uint64 fundingID) {
         uint256 actualFundAmount;
         (fundingID, actualFundAmount) = _fundRecordData(
             sender,

--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -78,7 +78,7 @@ contract Factory {
         bytes32 salt,
         address _pool,
         address _vesting,
-        uint256 _maturationTimetstamp,
+        uint64 _maturationTimetstamp,
         uint256 _initialDepositAmount,
         string calldata _tokenName,
         string calldata _tokenSymbol

--- a/contracts/models/fee/IFeeModel.sol
+++ b/contracts/models/fee/IFeeModel.sol
@@ -6,13 +6,13 @@ interface IFeeModel {
 
     function getInterestFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 interestAmount
     ) external view returns (uint256 feeAmount);
 
     function getEarlyWithdrawFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 withdrawnDepositAmount
     ) external view returns (uint256 feeAmount);
 }

--- a/contracts/models/fee/PercentageFeeModel.sol
+++ b/contracts/models/fee/PercentageFeeModel.sol
@@ -59,7 +59,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function getInterestFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 interestAmount
     ) external view override returns (uint256 feeAmount) {
         uint256 feeRate;
@@ -84,7 +84,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function getEarlyWithdrawFeeAmount(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 withdrawnDepositAmount
     ) external view override returns (uint256 feeAmount) {
         uint256 feeRate;
@@ -154,7 +154,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function overrideInterestFeeForDeposit(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 newFee
     ) external onlyOwner {
         require(newFee <= interestFee, "PercentageFeeModel: too big");
@@ -167,7 +167,7 @@ contract PercentageFeeModel is IFeeModel, Ownable {
 
     function overrideEarlyWithdrawFeeForDeposit(
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 newFee
     ) external onlyOwner {
         require(newFee <= earlyWithdrawFee, "PercentageFeeModel: too big");

--- a/contracts/models/issuance/IMPHIssuanceModel.sol
+++ b/contracts/models/issuance/IMPHIssuanceModel.sol
@@ -63,7 +63,7 @@ interface IMPHIssuanceModel {
         address pool,
         uint256 depositAmount,
         uint256 fundingCreationTimestamp,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool early
     )
         external
@@ -89,7 +89,7 @@ interface IMPHIssuanceModel {
         @notice The multiplier applied when minting MPH for a pool's depositor reward.
                 Unit is MPH-wei per depositToken-wei per second. (wei here is the smallest decimal place)
                 Scaled by 10^18.
-                NOTE: The depositToken's decimals matter! 
+                NOTE: The depositToken's decimals matter!
      */
     function poolDepositorRewardMintMultiplier(address pool)
         external

--- a/contracts/models/issuance/MPHIssuanceModel02.sol
+++ b/contracts/models/issuance/MPHIssuanceModel02.sol
@@ -20,7 +20,7 @@ contract MPHIssuanceModel02 is OwnableUpgradeable, IMPHIssuanceModel {
         @notice The multiplier applied when minting MPH for a pool's depositor reward.
                 Unit is MPH-wei per depositToken-wei per second. (wei here is the smallest decimal place)
                 Scaled by 10^18.
-                NOTE: The depositToken's decimals matter! 
+                NOTE: The depositToken's decimals matter!
      */
     mapping(address => uint256)
         public
@@ -167,7 +167,7 @@ contract MPHIssuanceModel02 is OwnableUpgradeable, IMPHIssuanceModel {
         address pool,
         uint256 depositAmount,
         uint256 fundingCreationTimestamp,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         bool early
     )
         external

--- a/contracts/rewards/MPHMinter.sol
+++ b/contracts/rewards/MPHMinter.sol
@@ -62,7 +62,7 @@ contract MPHMinter is MPHMinterLegacy {
     /**
         v3 functions
      */
-    function createVestForDeposit(address account, uint256 depositID)
+    function createVestForDeposit(address account, uint64 depositID)
         external
         onlyRole(WHITELISTED_POOL_ROLE)
     {
@@ -75,7 +75,7 @@ contract MPHMinter is MPHMinterLegacy {
     }
 
     function updateVestForDeposit(
-        uint256 depositID,
+        uint64 depositID,
         uint256 currentDepositAmount,
         uint256 depositAmount
     ) external onlyRole(WHITELISTED_POOL_ROLE) {
@@ -102,7 +102,7 @@ contract MPHMinter is MPHMinterLegacy {
         return amount;
     }
 
-    function distributeFundingRewards(uint256 fundingID, uint256 interestAmount)
+    function distributeFundingRewards(uint64 fundingID, uint256 interestAmount)
         external
         onlyRole(WHITELISTED_POOL_ROLE)
     {

--- a/contracts/rewards/MPHMinterLegacy.sol
+++ b/contracts/rewards/MPHMinterLegacy.sol
@@ -196,7 +196,7 @@ contract MPHMinterLegacy is AccessControlUpgradeable {
         address to,
         uint256 depositAmount,
         uint256 fundingCreationTimestamp,
-        uint256 maturationTimestamp,
+        uint64 maturationTimestamp,
         uint256 interestPayoutAmount,
         bool early
     ) external onlyRole(WHITELISTED_POOL_ROLE) returns (uint256) {

--- a/contracts/rewards/Vesting02.sol
+++ b/contracts/rewards/Vesting02.sol
@@ -24,7 +24,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
 
     struct Vest {
         address pool;
-        uint256 depositID;
+        uint64 depositID;
         uint256 lastUpdateTimestamp;
         uint256 accumulatedAmount;
         uint256 withdrawnAmount;
@@ -41,7 +41,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
     event ECreateVest(
         address indexed to,
         address indexed pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 vestAmountPerStablecoinPerSecond
     );
     event EUpdateVest(uint256 indexed vestID);
@@ -76,7 +76,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
     function createVestForDeposit(
         address to,
         address pool,
-        uint256 depositID,
+        uint64 depositID,
         uint256 vestAmountPerStablecoinPerSecond
     ) external returns (uint256 vestID) {
         require(
@@ -105,7 +105,7 @@ contract Vesting02 is ERC721URIStorageUpgradeable, OwnableUpgradeable {
     }
 
     function updateVestForDeposit(
-        uint256 depositID,
+        uint64 depositID,
         uint256 currentDepositAmount,
         uint256 depositAmount,
         uint256 vestAmountPerStablecoinPerSecond

--- a/contracts/zaps/ZapCurve.sol
+++ b/contracts/zaps/ZapCurve.sol
@@ -36,7 +36,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
         address inputToken,
         uint256 inputTokenAmount,
         uint256 minOutputTokenAmount,
-        uint256 maturationTimestamp
+        uint64 maturationTimestamp
     ) external active {
         DInterest poolContract = DInterest(pool);
         ERC20 stablecoin = poolContract.stablecoin();
@@ -54,7 +54,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
 
         // create deposit
         stablecoin.safeApprove(pool, outputTokenAmount);
-        (uint256 depositID, ) =
+        (uint64 depositID, ) =
             poolContract.deposit(outputTokenAmount, maturationTimestamp);
 
         // transfer deposit multitokens to msg.sender
@@ -74,7 +74,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
         address inputToken,
         uint256 inputTokenAmount,
         uint256 minOutputTokenAmount,
-        uint256 depositID
+        uint64 depositID
     ) external active {
         DInterest poolContract = DInterest(pool);
         ERC20 stablecoin = poolContract.stablecoin();
@@ -91,7 +91,7 @@ contract ZapCurve is ERC1155Receiver, IERC721Receiver {
 
         // create funding
         stablecoin.safeApprove(pool, outputTokenAmount);
-        uint256 fundingID = poolContract.fund(depositID, outputTokenAmount);
+        uint64 fundingID = poolContract.fund(depositID, outputTokenAmount);
 
         // transfer funding multitoken to msg.sender
         fundingMultitoken.safeTransferFrom(

--- a/contracts/zero-coupon-bond/ZeroCouponBond.sol
+++ b/contracts/zero-coupon-bond/ZeroCouponBond.sol
@@ -29,8 +29,8 @@ contract ZeroCouponBond is
     ERC20 public stablecoin;
     NFT public depositNFT;
     Vesting02 public vesting;
-    uint256 public maturationTimestamp;
-    uint256 public depositID;
+    uint64 public maturationTimestamp;
+    uint64 public depositID;
     uint8 public _decimals;
 
     event WithdrawDeposit();
@@ -41,7 +41,7 @@ contract ZeroCouponBond is
         address _creator,
         address _pool,
         address _vesting,
-        uint256 _maturationTimestamp,
+        uint64 _maturationTimestamp,
         uint256 _initialDepositAmount,
         string calldata _tokenName,
         string calldata _tokenSymbol


### PR DESCRIPTION
This changes both timestamps (`maturationTimestamp` and `depositTimestamp`) and `fundingID` and `depositID` from uint256 to uint64. It saves up to 7 % gas on the methods, but deployment gets up to 5 % more expensive.
In practise the gas savings should be even bigger, because the lists (`fundingList` and `deposits`) in production are even longer (than in the tests).

**The contract size is over 24k and thus several tests fail now.**

With `settings.debug.revertStrings = "strip"` the contracts are small enough, but then 30 tests fail, because they test revert strings.

```
CERC20Mock.mint:
min:  330471 ->  326733 (-1.1%)
max:  472428 ->  468690 (-0.8%)
avg:  364902 ->  361164 (-1.0%)
DInterest.deposit:
min:  552499 ->  513125 (-7.1%)
max:  738399 ->  699025 (-5.3%)
avg:  668214 ->  628839 (-5.9%)
DInterest.fund:
min:  256452 ->  256961 (0.2%)
max:  523511 ->  510793 (-2.4%)
avg:  396291 ->  385463 (-2.7%)
DInterest.payInterestToFunders:
min:  201421 ->  201695 (0.1%)
max:  358448 ->  358722 (0.1%)
avg:  257921 ->  258195 (0.1%)
DInterest.rolloverDeposit:
min:  529215 ->  488803 (-7.6%)
max:  672300 ->  631888 (-6.0%)
avg:  566370 ->  525958 (-7.1%)
DInterest.topupDeposit:
min:  261787 ->  258034 (-1.4%)
max:  403744 ->  399991 (-0.9%)
avg:  296218 ->  292465 (-1.3%)
DInterest.withdraw:
min:   78906 ->   78276 (-0.8%)
max:  382749 ->  380370 (-0.6%)
avg:  188683 ->  187520 (-0.6%)

Factory.createZeroCouponBond:
min: 1060529 ->  983322 (-7.3%)
max: 1166574 -> 1089367 (-6.6%)
avg: 1100119 -> 1022912 (-7.0%)

MPHIssuanceModel02.setPoolFunderRewardVestPeriod:
min:   26688 ->   26754 (0.2%)
max:   26700 ->   26766 (0.2%)
avg:   26699 ->   26765 (0.2%)

DInterest.DEPLOY:
avg: 4904146 -> 5143821 (4.9%)
Factory.DEPLOY:
avg: 1282064 -> 1287243 (0.4%)
MPHIssuanceModel02.DEPLOY:
avg:  824335 ->  833197 (1.1%)
MPHMinter.DEPLOY:
avg: 2403768 -> 2430977 (1.1%)
PercentageFeeModel.DEPLOY:
avg:  846664 ->  862235 (1.8%)
Vesting02.DEPLOY:
avg: 2387390 -> 2415235 (1.2%)
ZeroCouponBond.DEPLOY:
avg: 2010356 -> 2070353 (3.0%)
```
